### PR TITLE
chore(release): merge develop into main

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-fix": "eslint src test example --fix",
     "format": "prettier --check ./src/ ./test/ ./example/",
     "format-fix": "prettier --write ./src/ ./test/ ./example/",
-    "prepublishOnly": "tsc --noEmit && vite build"
+    "prepublishOnly": "corepack enable && yarn install --immutable && yarn build"
   },
   "main": "dist/planka-client.umd.cjs",
   "module": "dist/planka-client.js",


### PR DESCRIPTION
Promotes the corepack-based prepublishOnly so semantic-release can actually publish to npm. Currently npm has 2.0.1 latest while git tags v2.0.2 and v3.0.0 both exist — both publish attempts died at prepublishOnly.

## Changes

- **fix(release): use corepack for yarn install in prepublishOnly** ([56f3914](https://github.com/GEWIS/planka-client/commit/56f3914))
  - Confirmed in [GEWIS/actions npm-release.yml](https://github.com/GEWIS/actions/blob/v1/.github/workflows/npm-release.yml): the workflow runs `npm publish` with no prior install step, so prepublishOnly must install deps itself.
  - The GEWIS README's `yarn install --frozen-lockfile && yarn build` recipe is yarn 1 syntax and bombs on yarn 4 (`packageManager: yarn@4.5.1` makes yarn 1 refuse to run); the alternative `npm ci && npm run build` needs a committed `package-lock.json` we don't have.
  - This is the yarn-4 equivalent: `corepack enable && yarn install --immutable && yarn build`. Same install semantics as `npm ci`, uses our existing `yarn.lock`.
  - No `BREAKING CHANGE:` footer this time — next published version is **3.0.1** (3.0.0 was tagged but never published; npm registry will jump 2.0.1 → 3.0.1).

## Test plan

- [x] Locally simulated prepublishOnly with `node_modules` wiped and yarn stripped from PATH — produced `dist/planka-client.{js,d.ts,umd.cjs}` cleanly
- [ ] CI green on the merge commit
- [ ] Release workflow publishes 3.0.1 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)